### PR TITLE
(fix): zil2poly dsblock overwrite prevention

### DIFF
--- a/service/zil2poly.go
+++ b/service/zil2poly.go
@@ -124,6 +124,17 @@ T:
 		goto T
 	}
 	if txBlock.BlockHeader.DSBlockNum > s.currentDsBlockNum {
+		// as we can't control the order how the header4sync on the poly
+		// nodes after we sent it across,
+		// this will ensure that all the TXBlock for a given DSBlock are synced before
+		// we proceed with the next dsblock.
+		log.Infof("ZilliqaSyncManager - new DsBlock %d", txBlock.BlockHeader.DSBlockNum)
+		log.Infof("ZilliqaSyncManager - sync all the txblock for %d", s.currentDsBlockNum)
+		if res := s.commitHeader(); res != 0 {
+			log.Errorf("ZilliqaSyncManager MonitorChain -- commit header error, result %d", res)
+			return false
+		}
+
 		log.Infof("ZilliqaSyncManager - handleBlockHeader query ds block: %d\n", txBlock.BlockHeader.DSBlockNum)
 		dsBlock, err := s.zilSdk.GetDsBlockVerbose(strconv.FormatUint(txBlock.BlockHeader.DSBlockNum, 10))
 		if err != nil {


### PR DESCRIPTION
this change prevents us from adding to the header4sync tx blocks not included in the current dsblock.
This change is based on the assumption that despite the fact we can see that the header4sync is properly sorted on the relayer, we saw a dsblock can be override before the previous tx block are committed.
This ensure this can't happen and before start adding new dsblock and tx blocks to the header4sync the previous one are committed and the header to sync erased `s.header4sync = make([][]byte, 0)`.
There is a better way to do it changing the syncmanager but as first run I tried the implementation with this small hack.